### PR TITLE
restrict-controller-actions

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -22,15 +22,25 @@ class ArticlesController < ApplicationController
   end
 
   def edit
+    if @article.user != current_user
+      flash[:danger] = "You can only edit your own article."
+      redirect_to root_path
+    end
   end
 
   def update
-    if @article.update(article_params)
-      flash[:success] = "Article has been updated"
-      redirect_to @article
+
+    if @article.user != current_user
+      flash[:danger] = "You can only edit your own article."
+      redirect_to root_path
     else
-      flash.now[:danger] = "Article has not been updated"
-      render :edit
+      if @article.update(article_params)
+        flash[:success] = "Article has been updated"
+        redirect_to @article
+      else
+        flash.now[:danger] = "Article has not been updated"
+        render :edit
+      end
     end
   end
 

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -1,8 +1,37 @@
 require 'rails_helper'
+require 'support/macros'
 
 RSpec.describe ArticlesController, type: :controller do
 
   describe "GET #index" do
+    before do
+      @grace = User.create(email: "grace@example.com", password: "password")
+    end
+
+    context "owner is allowed to edit her articles" do
+      it "renders the edit template" do
+        login_user @grace
+        article = Article.create(title: "First Article", body: "Body text of first test article", user: @grace)
+
+        get :edit, id: article
+        expect(response).to render_template :edit
+      end
+    end
+
+    context "non-owner is not allowed to edit other users articles" do
+      it "redirects to the root path" do
+        @tamara = User.create(email: "tamara@example.com", password: "password")
+        login_user @tamara
+        article = Article.create(title: "First Article", body: "Body text of first test article", user: @grace)
+
+        get :edit, id: article
+        expect(response).to redirect_to(root_path)
+        message = "You can only edit your own article."
+        expect(flash[:danger]).to eq message
+      end
+    end
+
+
     it "returns http success" do
       get :index
       expect(response).to have_http_status(:success)

--- a/spec/support/macros.rb
+++ b/spec/support/macros.rb
@@ -1,0 +1,4 @@
+def login_user(user)
+  allow(request.env['warden']).to receive(:authenticate!) { user }
+  allow(controller).to receive(:current_user) { user }
+end


### PR DESCRIPTION
- implemented tests and if statements in controller to restrict access to controller actions. 
- tests passing. 
- wonder if this could also be accomplished with a before_action filter instead of repeating the logic in each action.
